### PR TITLE
log: optimize log for ignored warnings (RDT-419)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Stop writing `app_info` and `size_info` if the build got skipped
 - `IDF_VERSION_MAJOR`, `IDF_VERSION_MINOR`, `IDF_VERSION_PATCH` now are integers
 - Skip exclude files while removing build directory if files not exist
+- Use log level `INFO` for ignored warnings.
 
 ## [0.4.0]
 

--- a/idf_build_apps/app.py
+++ b/idf_build_apps/app.py
@@ -533,8 +533,10 @@ class CMakeApp(App):
             for line in lines:
                 is_error_or_warning, ignored = self.is_error_or_warning(line)
                 if is_error_or_warning:
-                    LOGGER.warning('%s', line)
-                    if not ignored:
+                    if ignored:
+                        LOGGER.info('[Ignored warning] %s', line)
+                    else:
+                        LOGGER.warning('%s', line)
                         has_unignored_warning = True
 
             if returncode != 0:


### PR DESCRIPTION
## Description

- We use `idf-build-apps` with ignore_warning_strs. When we have new warnings, it is not clear which warning is ignored and which is not.