### PR TITLE
fix: add missing dependency pyyaml back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- Add missing dependency `pyyaml`. It's wrongly removed in 0.6.0.
+
 ## [0.6.0] (2023-05-08)
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ requires-python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 dependencies = [
     "pathlib; python_version < '3.4'",
     "pyparsing",
+    "pyyaml",
     "packaging",
     "toml; python_version < '3.11'",
 ]


### PR DESCRIPTION
This reverts commit e448d7a96753d9a35b160807066366f5e7e319b7 somehow