### PR TITLE
fix: skip while collecting only when both depend components and files unmatched

### DIFF
--- a/idf_build_apps/app.py
+++ b/idf_build_apps/app.py
@@ -545,8 +545,10 @@ class App(object):
 
         if _modified_components == BuildOrNot.YES or _modified_files == BuildOrNot.YES:
             self.should_build = BuildOrNot.YES
-        elif _modified_components == BuildOrNot.NO or _modified_files == BuildOrNot.NO:
+        elif _modified_components == BuildOrNot.NO:  # _modified_files == BuildOrNot.NO or UNKNOWN
             self.should_build = BuildOrNot.NO
+        # elif modified_components == BuildOrNot.UNKNOWN and modified_files == BuildOrNot.No or UNKNOWN:
+        #     we left it unknown and decide with idf.py reconfigure
 
         self._checked_should_build = True
 

--- a/idf_build_apps/main.py
+++ b/idf_build_apps/main.py
@@ -315,7 +315,6 @@ def build_apps(
             LOGGER.info('=> Remove existing collect file %s', f)
         Path(f).touch()
 
-    actual_built_apps = []
     built_apps = []  # type: list[App]
     skipped_apps = []  # type: list[App]
     for i, app in enumerate(apps):
@@ -339,25 +338,22 @@ def build_apps(
                     manifest_rootpath, modified_components, modified_files, ignore_app_dependencies_filepatterns
                 ),
             )
-        except BuildError as e:
-            LOGGER.error(str(e))
-            if keep_going:
-                failed_apps.append(app)
-                exit_code = 1
-            else:
-                if modified_components is not None:
-                    return 1, actual_built_apps
-                else:
-                    return 1
-        finally:
             if is_built:
                 built_apps.append(app)
             else:
                 skipped_apps.append(app)
-
+        except BuildError as e:
+            LOGGER.error(str(e))
+            failed_apps.append(app)
+            if keep_going:
+                exit_code = 1
+            else:
+                if modified_components is not None:
+                    return 1, built_apps
+                else:
+                    return 1
+        finally:
             if is_built:
-                actual_built_apps.append(app)
-
                 if app.collect_app_info:
                     with open(app.collect_app_info, 'a') as fw:
                         fw.write(app.to_json() + '\n')
@@ -416,7 +412,7 @@ def build_apps(
             LOGGER.error('  %s', app)
 
     if modified_components is not None:
-        return exit_code, actual_built_apps
+        return exit_code, built_apps
     else:
         return exit_code
 


### PR DESCRIPTION
judge with `idf.py reconfigure` afterwards if undecided.