### PR TITLE
A few small fixes and improvements

### DIFF
--- a/idf_build_apps/app.py
+++ b/idf_build_apps/app.py
@@ -134,6 +134,7 @@ class App(BaseModel):
         self,
         app_dir: str,
         target: str,
+        *,
         sdkconfig_path: t.Optional[str] = None,
         config_name: t.Optional[str] = None,
         work_dir: t.Optional[str] = None,

--- a/idf_build_apps/app.py
+++ b/idf_build_apps/app.py
@@ -33,6 +33,9 @@ from pydantic import (
 from . import (
     LOGGER,
 )
+from .build_job import (
+    BuildJob,
+)
 from .constants import (
     DEFAULT_SDKCONFIG,
     IDF_PY,
@@ -79,7 +82,6 @@ class App(BaseModel):
     NAME_PLACEHOLDER: t.ClassVar[str] = '@n'  # replace it with self.name
     FULL_NAME_PLACEHOLDER: t.ClassVar[str] = '@f'  # replace it with escaped self.app_dir
     INDEX_PLACEHOLDER: t.ClassVar[str] = '@i'  # replace it with the build index
-    PARALLEL_INDEX_PLACEHOLDER: t.ClassVar[str] = '@p'  # replace it with the parallel index
     IDF_VERSION_PLACEHOLDER: t.ClassVar[str] = '@v'  # replace it with the IDF version
 
     BUILD_SYSTEM: t.ClassVar[str] = 'unknown'
@@ -113,19 +115,16 @@ class App(BaseModel):
     _build_log_path: t.Optional[str] = None
     _size_json_path: t.Optional[str] = None
 
-    _collect_app_info: t.Optional[str] = None
-    _collect_size_info: t.Optional[str] = None
-
     # Build related
     dry_run: bool = False
     index: t.Union[int, None] = None
     verbose: bool = False
     check_warnings: bool = False
     preserve: bool = True
-    parallel_index: int = 1
-    parallel_count: int = 1
 
     # logging
+    build_job: t.Optional[BuildJob] = BuildJob()
+
     _build_stage: t.Optional[BuildStage] = None
     _build_duration: float = 0
     _build_timestamp: t.Optional[datetime] = None
@@ -168,9 +167,6 @@ class App(BaseModel):
         self._build_log_path = build_log_path
         self._size_json_path = size_json_path
 
-        self._collect_app_info = None
-        self._collect_size_info = None
-
         # should be built or not
         self._checked_should_build = False
 
@@ -212,7 +208,7 @@ class App(BaseModel):
 
         if self.index is not None:
             path = path.replace(self.INDEX_PLACEHOLDER, str(self.index))
-        path = path.replace(self.PARALLEL_INDEX_PLACEHOLDER, str(self.parallel_index))
+        path = self.build_job.expand(path)
         path = path.replace(
             self.IDF_VERSION_PLACEHOLDER, f'{IDF_VERSION_MAJOR}_{IDF_VERSION_MINOR}_{IDF_VERSION_PATCH}'
         )
@@ -274,22 +270,6 @@ class App(BaseModel):
     def size_json_path(self) -> t.Optional[str]:
         if self._size_json_path:
             return os.path.join(self.build_path, self._expand(self._size_json_path))
-
-        return None
-
-    @computed_field
-    @property
-    def collect_app_info(self) -> t.Optional[str]:
-        if self._collect_app_info:
-            return self._expand(self._collect_app_info)
-
-        return None
-
-    @computed_field
-    @property
-    def collect_size_info(self) -> t.Optional[str]:
-        if self._collect_size_info:
-            return self._expand(self._collect_size_info)
 
         return None
 

--- a/idf_build_apps/app.py
+++ b/idf_build_apps/app.py
@@ -27,7 +27,6 @@ from packaging.version import (
     Version,
 )
 from pydantic import (
-    BaseModel,
     computed_field,
 )
 
@@ -51,6 +50,7 @@ from .manifest.manifest import (
     Manifest,
 )
 from .utils import (
+    BaseModel,
     BuildError,
     files_matches_patterns,
     find_first_match,
@@ -191,37 +191,6 @@ class App(BaseModel):
             self.build_status.value,
             self._build_duration,
         )
-
-    def __lt__(self, other: t.Any) -> bool:
-        if isinstance(other, App):
-            for k in self.model_dump():
-                if getattr(self, k) != getattr(other, k):
-                    return getattr(self, k) < getattr(other, k)
-                else:
-                    continue
-
-        return NotImplemented
-
-    def __eq__(self, other: t.Any) -> bool:
-        if isinstance(other, App):
-            self_dict = self.model_dump()
-            other_dict = other.model_dump()
-
-            return self_dict == other_dict
-
-        return NotImplemented
-
-    def __hash__(self) -> int:
-        hash_list = []
-        for v in self.__dict__.values():
-            if isinstance(v, list):
-                hash_list.append(tuple(v))
-            elif isinstance(v, dict):
-                hash_list.append(tuple(v.items()))
-            else:
-                hash_list.append(v)
-
-        return hash((type(self),) + tuple(hash_list))
 
     @staticmethod
     def _get_sdkconfig_defaults(sdkconfig_defaults_str: t.Optional[str] = None) -> t.List[str]:

--- a/idf_build_apps/build_job.py
+++ b/idf_build_apps/build_job.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+
+import typing as t
+
+from pydantic import (
+    computed_field,
+)
+
+from .utils import (
+    BaseModel,
+)
+
+
+class BuildJob(BaseModel):
+    PARALLEL_INDEX_PLACEHOLDER: t.ClassVar[str] = '@p'  # replace it with the parallel index
+
+    parallel_index: int = 1
+    parallel_count: int = 1
+
+    _junitxml: t.Optional[str] = None
+    _collect_app_info: t.Optional[str] = None
+    _collect_size_info: t.Optional[str] = None
+
+    def __init__(
+        self,
+        *,
+        collect_app_info: t.Optional[str] = None,
+        collect_size_info: t.Optional[str] = None,
+        junitxml: t.Optional[str] = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        self._junitxml = junitxml
+        self._collect_app_info = collect_app_info
+        self._collect_size_info = collect_size_info
+
+    @computed_field
+    @property
+    def collect_app_info(self) -> t.Optional[str]:
+        if self._collect_app_info:
+            return self.expand(self._collect_app_info)
+
+        return None
+
+    @computed_field
+    @property
+    def collect_size_info(self) -> t.Optional[str]:
+        if self._collect_size_info:
+            return self.expand(self._collect_size_info)
+
+        return None
+
+    @computed_field
+    @property
+    def junitxml(self) -> t.Optional[str]:
+        if self._junitxml:
+            return self.expand(self._junitxml)
+
+        return None
+
+    def expand(self, path):
+        return path.replace(self.PARALLEL_INDEX_PLACEHOLDER, str(self.parallel_index))

--- a/idf_build_apps/junit/report.py
+++ b/idf_build_apps/junit/report.py
@@ -38,6 +38,9 @@ from datetime import (
     datetime,
 )
 from xml.etree import ElementTree as ET
+from xml.sax.saxutils import (
+    escape,
+)
 
 from .. import (
     LOGGER,
@@ -118,11 +121,11 @@ class TestCase:
             },
         )
         if self.error_reason:
-            ET.SubElement(elem, 'error', {'message': self.error_reason})
+            ET.SubElement(elem, 'error', {'message': escape(self.error_reason)})
         elif self.failure_reason:
-            ET.SubElement(elem, 'failure', {'message': self.failure_reason})
+            ET.SubElement(elem, 'failure', {'message': escape(self.failure_reason)})
         elif self.skipped_reason:
-            ET.SubElement(elem, 'skipped', {'message': self.skipped_reason})
+            ET.SubElement(elem, 'skipped', {'message': escape(self.skipped_reason)})
 
         return elem
 

--- a/idf_build_apps/junit/report.py
+++ b/idf_build_apps/junit/report.py
@@ -39,6 +39,9 @@ from datetime import (
 )
 from xml.etree import ElementTree as ET
 
+from .. import (
+    LOGGER,
+)
 from ..app import (
     App,
 )
@@ -188,3 +191,4 @@ class TestReport:
             xml.append(test_suite.to_xml_elem())
 
         ET.ElementTree(xml).write(self.filepath, encoding='utf-8')
+        LOGGER.info('Test report written to %s', self.filepath)

--- a/idf_build_apps/log.py
+++ b/idf_build_apps/log.py
@@ -22,7 +22,7 @@ class ColoredFormatter(logging.Formatter):
     reset: str = '\x1b[0m'
 
     fmt: str = '%(asctime)s %(levelname)8s %(message)s'
-    app_fmt: str = f'%(asctime)s %(levelname)8s %(build_stage){BuildStage.max_length()}s| %(message)s'
+    app_fmt: str = f'%(asctime)s %(levelname)8s [%(build_stage){BuildStage.max_length()}s] %(message)s'
 
     datefmt: str = '%Y-%m-%d %H:%M:%S'
 

--- a/idf_build_apps/manifest/manifest.py
+++ b/idf_build_apps/manifest/manifest.py
@@ -170,6 +170,10 @@ class Manifest:
 
         rules = []  # type: list[FolderRule]
         for folder, folder_rule in manifest_dict.items():
+            # not a folder, but a anchor
+            if folder.startswith('.'):
+                continue
+
             if os.path.isabs(folder):
                 folder = Path(folder)
             else:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -110,7 +110,7 @@ class TestBuild:
             CMakeApp(test_dir, 'esp32', build_dir='build_2'),
         ]
 
-        build_apps(deepcopy(apps), dry_run=True, junitxml_filepath=str(tmpdir / 'test.xml'))
+        build_apps(deepcopy(apps), dry_run=True, junitxml=str(tmpdir / 'test.xml'))
 
         with open(tmpdir / 'test.xml') as f:
             xml = ET.fromstring(f.read())
@@ -127,7 +127,7 @@ class TestBuild:
             assert testcase.find('skipped') is not None
             assert testcase.find('skipped').attrib['message'] == 'dry run'
 
-        build_apps(deepcopy(apps), junitxml_filepath=str(tmpdir / 'test.xml'))
+        build_apps(deepcopy(apps), junitxml=str(tmpdir / 'test.xml'))
 
         with open(tmpdir / 'test.xml') as f:
             xml = ET.fromstring(f.read())


### PR DESCRIPTION
- feat: record size_json into junitxml if exists
- fix: escape string in junitxml
- feat: Support placeholder `@p` in junitxml
- refactor: move common magic methods into a new BaseModel class
- chore: add one log when generated the junit report
- feat!: make `App` init function keyword-only for most of the params
- fix: manifest folder rule starts with a `.` will be skipped checking existence
- fix: log format more visible, from `BUILD_STAGE|` to `[BUILD_STAGE]`
