### PR TITLE
feat: support override sdkconfig cli options (RDT-569)

### DIFF
--- a/docs/find_build.md
+++ b/docs/find_build.md
@@ -52,10 +52,11 @@ The default sdkconfig file for test-1 would be generated in this order:
 flowchart TB
     kconfig(Kconfig default values)
     sdkconfig_defaults(sdkconfig.defaults)
+    sdkconfig_override(sdkconfig.override)
     sdkconfig_defaults_target(sdkconfig.defaults.TARGET)
     sdkconfig_file(sdkconfig file)
 
-    sdkconfig_defaults -- be overriden by --> sdkconfig_defaults_target -- configure together with --> kconfig -- populates --> sdkconfig_file
+    sdkconfig_defaults -- be overriden by --> sdkconfig_defaults_target -- be overriden by--> sdkconfig_override -- configure together with --> kconfig -- populates --> sdkconfig_file
 
     subgraph "which would only be applied when building with the corresponding target"
     sdkconfig_defaults_target
@@ -127,6 +128,22 @@ Will output:
 For each `SDKCONFIG_FILEPATTERN`, only one wildcard is supported.
 ```
 
+There are options available to globally override sdkconfig:
+- `--override-sdkconfig-items`
+- `--override-sdkconfig-files`
+
+If you use multiple `config rules` options together, the priority is as follows:
+- `--override-sdkconfig-items` has the highest priority
+- `--override-sdkconfig-files` has the next priority
+- All other options have lower priority
+
+The files for `--override-sdkconfig-files` should be a comma-separated list of file paths. Each path is an abusolute path, or a relative path to the current work directory.
+
+For example,
+
+```shell
+idf-build-apps find -p test-1 --recursive --target esp32 --override-sdkconfig-files sdkconfig.o1,sdkconfig.o2 --override-sdkconfig-items CONFIG_A=4,CONFIG_B=5
+```
 ### Placeholders for Work Directory and Build Directory
 
 As native ESP-IDF does, `idf-build-apps` builds projects in-place, within the project directory, and generates the binaries under `build` directory. `idf-build-apps` also provides a way to customize the work directory and build directory.

--- a/idf_build_apps/__init__.py
+++ b/idf_build_apps/__init__.py
@@ -11,8 +11,13 @@ Tools for building ESP-IDF related apps.
 import logging
 
 __version__ = '2.0.0b4'
-
 LOGGER = logging.getLogger('idf_build_apps')
+
+from .session_args import (
+    SessionArgs,
+)
+
+SESSION_ARGS = SessionArgs()
 
 from .app import (
     App,

--- a/idf_build_apps/app.py
+++ b/idf_build_apps/app.py
@@ -31,11 +31,15 @@ from pydantic import (
     computed_field,
 )
 
+from idf_build_apps import (
+    SESSION_ARGS,
+)
+
 from . import (
     LOGGER,
 )
 from .build_job import (
-    BuildJob,
+    BuildAppJob,
 )
 from .constants import (
     DEFAULT_SDKCONFIG,
@@ -125,7 +129,7 @@ class App(BaseModel):
     preserve: bool = True
 
     # logging
-    build_job: t.Optional[BuildJob] = BuildJob()
+    build_job: t.Optional[BuildAppJob] = BuildAppJob()
 
     _build_stage: t.Optional[BuildStage] = None
     _build_duration: float = 0
@@ -188,6 +192,7 @@ class App(BaseModel):
         # create logger and process sdkconfig files
         self._logger = LOGGER.getChild(str(hash(self)))
         self._logger.addFilter(_AppBuildStageFilter(app=self))
+
         self._process_sdkconfig_files()
 
     def _initialize_hook(self, **kwargs):
@@ -378,6 +383,11 @@ class App(BaseModel):
             os.rmdir(os.path.join(self.work_dir, 'expanded_sdkconfig_files'))
         except OSError:
             pass
+
+        if SESSION_ARGS.override_sdkconfig_items:
+            res.append(SESSION_ARGS.override_sdkconfig_file_path)
+            if 'CONFIG_IDF_TARGET' in SESSION_ARGS.override_sdkconfig_items:
+                self._sdkconfig_files_defined_target = SESSION_ARGS.override_sdkconfig_items['CONFIG_IDF_TARGET']
 
         self._sdkconfig_files = res
 

--- a/idf_build_apps/build_job.py
+++ b/idf_build_apps/build_job.py
@@ -12,7 +12,7 @@ from .utils import (
 )
 
 
-class BuildJob(BaseModel):
+class BuildAppJob(BaseModel):
     PARALLEL_INDEX_PLACEHOLDER: t.ClassVar[str] = '@p'  # replace it with the parallel index
 
     parallel_index: int = 1

--- a/idf_build_apps/main.py
+++ b/idf_build_apps/main.py
@@ -15,6 +15,7 @@ from pathlib import (
 
 from . import (
     LOGGER,
+    SESSION_ARGS,
 )
 from .app import (
     App,
@@ -22,7 +23,7 @@ from .app import (
     MakeApp,
 )
 from .build_job import (
-    BuildJob,
+    BuildAppJob,
 )
 from .config import (
     get_valid_config,
@@ -224,7 +225,7 @@ def build_apps(
     modified_files: t.Optional[t.Union[t.List[str], str]] = None,
     ignore_app_dependencies_filepatterns: t.Optional[t.Union[t.List[str], str]] = None,
     check_app_dependencies: t.Optional[bool] = None,
-    # BuildJob
+    # BuildAppJob
     parallel_count: int = 1,
     parallel_index: int = 1,
     collect_size_info: t.Optional[t.Union[str, t.TextIO]] = None,
@@ -284,7 +285,7 @@ def build_apps(
     else:
         LOGGER.info('  parallel count is too large. build nothing...')
 
-    build_job = BuildJob(
+    build_job = BuildAppJob(
         parallel_count=parallel_count,
         parallel_index=parallel_index,
         collect_size_info=collect_size_info,
@@ -502,6 +503,26 @@ def get_parser() -> argparse.ArgumentParser:
         'the sdkconfig file, relative to the project directory, with at most one wildcard. '
         'The part captured by the wildcard is used as the name of the configuration',
     )
+
+    common_args.add_argument(
+        '--override-sdkconfig-items',
+        nargs='?',
+        type=str,
+        help='The --override-sdkconfig-items option is a comma-separated list '
+        'that permits the overriding of specific configuration items defined '
+        'in the SDK\'s sdkconfig file and Kconfig using a command-line argument. '
+        'The sdkconfig items specified here override the same sdkconfig '
+        'item defined in the --override-sdkconfig-files, if exists.',
+    )
+    common_args.add_argument(
+        '--override-sdkconfig-files',
+        nargs='?',
+        type=str,
+        help='"The --override-sdkconfig-files option is a comma-separated list, '
+        'which provides an alternative (alt: --override-sdkconfig-items) '
+        'approach for overriding SDK configuration items. '
+        'The filepath may be global or relative to the root.',
+    )
     common_args.add_argument(
         '--sdkconfig-defaults',
         help='semicolon-separated string, pass to idf.py -DSDKCONFIG_DEFAULTS if specified, also could be set via '
@@ -710,6 +731,7 @@ def main():
     apply_config_args(args)
     validate_args(parser, args)
 
+    SESSION_ARGS.set(args)
     # real call starts here
     apps = find_apps(
         args.paths,

--- a/idf_build_apps/session_args.py
+++ b/idf_build_apps/session_args.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2023 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import re
+import typing as t
+
+
+class SessionArgs:
+    workdir: str = os.getcwd()
+    override_sdkconfig_items: t.Dict[str, t.Any] = {}
+    override_sdkconfig_file_path: t.Optional[str] = None
+
+    def set(self, parsed_args, *, workdir=None):
+        if workdir:
+            self.workdir = workdir
+        self._setup_override_sdkconfig(parsed_args)
+
+    def clean(self):
+        self.override_sdkconfig_items = {}
+        self.override_sdkconfig_file_path = None
+
+    def _setup_override_sdkconfig(self, args):
+        override_sdkconfig_items = self._get_override_sdkconfig_items(
+            args.override_sdkconfig_items.split(',') if args.override_sdkconfig_items else ()
+        )
+        override_sdkconfig_files_items = self._get_override_sdkconfig_files_items(
+            args.override_sdkconfig_files.split(',') if args.override_sdkconfig_files else ()
+        )
+
+        override_sdkconfig_files_items.update(override_sdkconfig_items)
+        self.override_sdkconfig_items = override_sdkconfig_files_items
+
+        override_sdkconfig_merged_file = self._create_override_sdkconfig_merged_file(self.override_sdkconfig_items)
+        self.override_sdkconfig_file_path = override_sdkconfig_merged_file
+
+    def _get_override_sdkconfig_files_items(self, override_sdkconfig_files: t.Tuple[str]) -> t.Dict:
+        dct = {}
+        for f in override_sdkconfig_files:
+            if not os.path.isabs(f):
+                f = os.path.join(self.workdir, f)
+            if not os.path.isfile(f):
+                continue
+            with open(f) as fr:
+                for line in fr:
+                    m = re.compile(r"^([^=]+)=\"?([^\"\n]*)\"?\n*$").match(line)
+                    if not m:
+                        continue
+                    dct[m.group(1)] = m.group(2)
+        return dct
+
+    def _get_override_sdkconfig_items(self, override_sdkconfig_items: t.Tuple[str]) -> t.Dict:
+        dct = {}
+        for line in override_sdkconfig_items:
+            m = re.compile(r"^([^=]+)=\"?([^\"\n]*)\"?\n*$").match(line)
+            if m:
+                dct[m.group(1)] = m.group(2)
+        return dct
+
+    def _create_override_sdkconfig_merged_file(self, override_sdkconfig_merged_items) -> t.Optional[str]:
+        if not override_sdkconfig_merged_items:
+            return None
+        f_path = os.path.join(self.workdir, 'override-result.sdkconfig')
+        with open(f_path, 'w+') as f:
+            for key, value in override_sdkconfig_merged_items.items():
+                f.write(f'{key}={value}\n')
+        return f_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import os
 
 import pytest
 
+import idf_build_apps
 from idf_build_apps import (
     App,
     setup_logging,
@@ -13,6 +14,7 @@ from idf_build_apps import (
 @pytest.fixture(autouse=True)
 def clean_cls_attr():
     App.MANIFEST = None
+    idf_build_apps.SESSION_ARGS.clean()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Add a feature that helps with overriding sdkconfig files. 
The CLI arguments are as follows: 
- --override-sdkconfig CONFIG_FOO=y,CONFIG_BAR=n 
- --override-sdkconfig-file sdkconfig.override 
The last argument is considered with higher priority.

Examples
---
For example, we have 
```python
#sdkconfig.override1
CONFIG_FOO=y_2
```


```python
#sdkconfig.override2
CONFIG_FOO=n_2
```

ex1
---
```sh
--override-sdkconfig CONFIG_FOO=y_1,CONFIG_FOO=n_1 --override-sdkconfig-file sdkconfig.override1,sdkconfig.override2
```

Result will be: 
```python
CONFIG_FOO=n_2
```

ex2
---
```python
--override-sdkconfig-file sdkconfig.override1,sdkconfig.override2 --override-sdkconfig CONFIG_FOO=y_1,CONFIG_FOO=n_1
```

Result will be: 
```python
CONFIG_FOO=n_1
```
