### PR TITLE
add check_app_dependencies param in build_apps

### DIFF
--- a/idf_build_apps/app.py
+++ b/idf_build_apps/app.py
@@ -270,6 +270,10 @@ class App(BaseModel):
     @computed_field
     @property
     def size_json_path(self) -> t.Optional[str]:
+        if self.target == 'linux':
+            # esp-idf-size does not support linux target
+            return None
+
         if self._size_json_path:
             return os.path.join(self.build_path, self._expand(self._size_json_path))
 

--- a/idf_build_apps/main.py
+++ b/idf_build_apps/main.py
@@ -208,6 +208,7 @@ def build_apps(
     modified_components: t.Optional[t.Union[t.List[str], str]] = None,
     modified_files: t.Optional[t.Union[t.List[str], str]] = None,
     ignore_app_dependencies_filepatterns: t.Optional[t.Union[t.List[str], str]] = None,
+    check_app_dependencies: t.Optional[bool] = None,
     # BuildJob
     parallel_count: int = 1,
     parallel_index: int = 1,
@@ -232,6 +233,8 @@ def build_apps(
     :param modified_files: modified files
     :param ignore_app_dependencies_filepatterns: file patterns that used for ignoring checking the component
         dependencies
+    :param check_app_dependencies: check app dependencies or not. if not set, will be calculated by modified_components,
+        modified_files, and ignore_app_dependencies_filepatterns
     :param parallel_count: number of parallel tasks to run
     :param parallel_index: index of the parallel task to run
     :param collect_size_info: file path to record all generated size files' paths if specified
@@ -301,7 +304,9 @@ def build_apps(
             modified_files=modified_files,
             check_app_dependencies=_check_app_dependency(
                 manifest_rootpath, modified_components, modified_files, ignore_app_dependencies_filepatterns
-            ),
+            )
+            if check_app_dependencies is None
+            else check_app_dependencies,
         )
         test_suite.add_test_case(TestCase.from_app(app))
 


### PR DESCRIPTION
also make app.size_json_path always returns None for linux target apps since esp-idf-size does not support linux yet