### PR TITLE
Feature: find_apps support customer app class (RDT-589)

### DIFF
--- a/idf_build_apps/app.py
+++ b/idf_build_apps/app.py
@@ -158,9 +158,6 @@ class App(BaseModel):
             }
         )
         super().__init__(**kwargs)
-        self._logger = LOGGER.getChild(str(hash(self)))
-        self._logger.addFilter(_AppBuildStageFilter(app=self))
-
         # These internal variables store the paths with environment variables and placeholders;
         # Public properties with similar names use the _expand method to get the actual paths.
         self._work_dir = work_dir or app_dir
@@ -177,7 +174,27 @@ class App(BaseModel):
         self._sdkconfig_files = None
         self._sdkconfig_files_defined_target = None
 
+        # pass all parameters to initialize hook method
+        kwargs.update(
+            {
+                'work_dir': work_dir,
+                'build_dir': build_dir,
+                'build_log_filename': build_log_filename,
+                'size_json_filename': size_json_filename,
+                'sdkconfig_defaults_str': sdkconfig_defaults_str,
+            }
+        )
+        self._initialize_hook(**kwargs)
+        # create logger and process sdkconfig files
+        self._logger = LOGGER.getChild(str(hash(self)))
+        self._logger.addFilter(_AppBuildStageFilter(app=self))
         self._process_sdkconfig_files()
+
+    def _initialize_hook(self, **kwargs):
+        """
+        Called after variables initialized, before actions such as creating logger.
+        """
+        pass
 
     def __str__(self):
         return '({}) App {}, target {}, sdkconfig {}, build in {}, {} in {}s'.format(


### PR DESCRIPTION
I needs some specific features in my project:
- Building eco versions with different folder names
- Pre process magic sdkconfig files

I was able to achieve them in this way with this PR:
```python
class MyApp(CMakeApp):
    ECO_VERSION_PLACEHOLDER = '@e'  # replace it with the ECO version
    _eco: str

    def __init__(self, *args, **kwargs):
        if 'eco' not in kwargs:
            kwargs['eco'] = ''
        super().__init__(*args, **kwargs)

    def _initialize_hook(self, **kwargs):
        self._eco = kwargs['eco']

    def _expand(self, path: str) -> str:
        path = super()._expand(path)
        return path.replace(self.ECO_VERSION_PLACEHOLDER, self._eco)

    def _process_sdkconfig_files(self):
        import jinja2
        ...
        pass


apps = find_apps('xxx', build_system=MyApp, xxx)
apps = _filter_or_duplicate(apps)
build_apps(apps, xxxx)
```

