### PR TITLE
feat: App support init "from_another" (RDT-635)

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -93,3 +93,14 @@ def test_app_deserializer():
         assert json_to_app(c.to_json()) == c
 
     assert json_to_app(c.to_json(), extra_classes=[CustomApp]) == c
+
+
+def test_app_init_from_another():
+    a = CMakeApp('foo', 'esp32', build_dir='build_@t_')
+    b = CMakeApp.from_another(a, target='esp32c3')
+
+    assert isinstance(b, CMakeApp)
+    assert a.target == 'esp32'
+    assert b.target == 'esp32c3'
+    assert 'build_esp32_' == a.build_dir
+    assert 'build_esp32c3_' == b.build_dir


### PR DESCRIPTION
My usage

```python
apps = find_apps()
for app in apps:
    eco7_app = MyApp.from_another(app, eco='eco7')
```

App based on BaseModel. And `App.__init__` including `logger` and `_process_sdkconfig_files `, can not change after init.