### PR TITLE
fix: same manifest folder rules shouldn't be declared multi times

### DIFF
--- a/idf_build_apps/main.py
+++ b/idf_build_apps/main.py
@@ -164,12 +164,7 @@ def find_apps(
     Manifest.CHECK_MANIFEST_RULES = check_manifest_rules
 
     if manifest_files:
-        rules = set()
-        for _manifest_file in to_list(manifest_files):
-            LOGGER.debug('Loading manifest file: %s', _manifest_file)
-            rules.update(Manifest.from_file(_manifest_file).rules)
-        manifest = Manifest(rules)
-        App.MANIFEST = manifest
+        App.MANIFEST = Manifest.from_files(to_list(manifest_files))
 
     modified_components = to_list(modified_components)
     modified_files = to_list(modified_files)


### PR DESCRIPTION
warn users with a warning, raise exception when user passed --check-manifest-rules flag