### PR TITLE
feat: implement SwitchClause

### DIFF
--- a/idf_build_apps/app.py
+++ b/idf_build_apps/app.py
@@ -437,14 +437,18 @@ class App(BaseModel):
     @property
     def depends_components(self) -> t.List[str]:
         if self.MANIFEST:
-            return self.MANIFEST.depends_components(self.app_dir)
+            return self.MANIFEST.depends_components(
+                self.app_dir, self.sdkconfig_files_defined_idf_target, self.config_name
+            )
 
         return []
 
     @property
     def depends_filepatterns(self) -> t.List[str]:
         if self.MANIFEST:
-            return self.MANIFEST.depends_filepatterns(self.app_dir)
+            return self.MANIFEST.depends_filepatterns(
+                self.app_dir, self.sdkconfig_files_defined_idf_target, self.config_name
+            )
 
         return []
 

--- a/idf_build_apps/yaml/parser.py
+++ b/idf_build_apps/yaml/parser.py
@@ -23,23 +23,39 @@ def parse_postfixes(manifest_dict: t.Dict):
 
             operation = key[-1]
 
-            dict_obj = []
+            if_dict_obj = []
+            other_dict_obj = []
             str_obj = set()
             for obj in updated_folder[key[:-1]]:
                 if isinstance(obj, t.Dict):
-                    dict_obj.append(obj)
+                    if 'if' in obj:
+                        if_dict_obj.append(obj)
+                    else:
+                        other_dict_obj.append(obj)
                 else:
                     str_obj.add(obj)
 
             for obj in folder_rule[key]:
                 if isinstance(obj, t.Dict):
-                    dict_obj = [obj_j for obj_j in dict_obj if obj['if'] != obj_j['if']]
+                    _l = obj['if']
+                    if isinstance(_l, str):
+                        _l = _l.replace(' ', '')
+
+                    new_dict_obj = []
+                    for obj_j in if_dict_obj:
+                        _r = obj_j['if']
+                        if isinstance(_r, str):
+                            _r = _r.replace(' ', '')
+                        if _l != _r:
+                            new_dict_obj.append(obj_j)
+                    if_dict_obj = new_dict_obj
+
                     if operation == '+':
-                        dict_obj.append(obj)
+                        if_dict_obj.append(obj)
                 else:
                     str_obj.add(obj) if operation == '+' else str_obj.remove(obj)
 
-            updated_folder[key[:-1]] = dict_obj + sorted(str_obj)
+            updated_folder[key[:-1]] = if_dict_obj + other_dict_obj + sorted(str_obj)
 
         manifest_dict[folder] = updated_folder
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -69,6 +69,126 @@ test2:
     assert manifest.enable_build_targets('test23') == sorted(SUPPORTED_TARGETS)
 
 
+def test_manifest_switch_clause(tmpdir, recwarn, monkeypatch):
+    yaml_file = tmpdir / 'test.yml'
+    from idf_build_apps.constants import (
+        IDF_VERSION,
+    )
+
+    yaml_file.write_text(
+        f"""
+test1:
+  depends_components:
+    - if: IDF_VERSION == "{IDF_VERSION}"
+      content: [ "VVV" ]
+    - if: CONFIG_NAME == "AAA"
+      content: [ "AAA" ]
+    - default: ["some_1", "some_2", "some_3"]
+
+test2:
+  depends_components:
+    - if: IDF_TARGET == "esp32"
+      content: [ "esp32" ]
+    - if: CONFIG_NAME == "AAA"
+      content: [ "AAA" ]
+    - if: IDF_VERSION == "{IDF_VERSION}"
+      content: [ "VVV" ]
+    - default: ["some_1", "some_2", "some_3"]
+
+test3:
+  depends_components:
+    - if: CONFIG_NAME == "AAA"
+      content: [ "AAA" ]
+    - if: CONFIG_NAME == "BBB"
+      content: [ "BBB" ]
+    - default: ["some_1", "some_2", "some_3"]
+
+test4:
+  depends_components:
+    - if: CONFIG_NAME == "BBB"
+      content: [ "BBB" ]
+    - if: CONFIG_NAME == "AAA"
+      content: [ "AAA" ]
+
+test5:
+  depends_components:
+    - "some_1"
+    - "some_2"
+    - "some_3"
+
+""",
+        encoding='utf8',
+    )
+
+    os.chdir(tmpdir)
+    Manifest.ROOTPATH = tmpdir
+    manifest = Manifest.from_file(yaml_file)
+
+    assert manifest.depends_components('test1', None, None) == ['VVV']
+    assert manifest.depends_components('test1', None, 'AAA') == ['VVV']
+
+    assert manifest.depends_components('test2', 'esp32', None) == ['esp32']
+    assert manifest.depends_components('test2', None, 'AAA') == ['AAA']
+    assert manifest.depends_components('test2', 'esp32', 'AAA') == ['esp32']
+    assert manifest.depends_components('test2', None, None) == ['VVV']
+
+    assert manifest.depends_components('test3', 'esp32', 'AAA') == ['AAA']
+    assert manifest.depends_components('test3', 'esp32', 'BBB') == ['BBB']
+    assert manifest.depends_components('test3', 'esp32', '123123') == ['some_1', 'some_2', 'some_3']
+    assert manifest.depends_components('test3', None, None) == ['some_1', 'some_2', 'some_3']
+
+    assert manifest.depends_components('test4', 'esp32', 'AAA') == ['AAA']
+    assert manifest.depends_components('test4', 'esp32', 'BBB') == ['BBB']
+    assert manifest.depends_components('test4', 'esp32', '123123') == []
+    assert manifest.depends_components('test4', None, None) == []
+
+    assert manifest.depends_components('test5', 'esp32', 'AAA') == ['some_1', 'some_2', 'some_3']
+    assert manifest.depends_components('test5', 'esp32', 'BBB') == ['some_1', 'some_2', 'some_3']
+    assert manifest.depends_components('test5', 'esp32', '123123') == ['some_1', 'some_2', 'some_3']
+    assert manifest.depends_components('test5', None, None) == ['some_1', 'some_2', 'some_3']
+
+
+def test_manifest_switch_clause_wrong_manifest_format(tmpdir, recwarn, monkeypatch):
+    yaml_file = tmpdir / 'test.yml'
+    from idf_build_apps.constants import (
+        IDF_VERSION,
+    )
+
+    yaml_file.write_text(
+        f"""
+    test1:
+      depends_components:
+        - if: IDF_VERSION == "{IDF_VERSION}"
+          content: [ "VVV" ]
+        - default: ["some_1", "some_2", "some_3"]
+        - hello: 123
+
+    """,
+        encoding='utf8',
+    )
+    try:
+        Manifest.from_file(yaml_file)
+    except InvalidManifest as e:
+        assert str(e) == "Only the 'if' and 'default' keywords are supported in switch clause."
+
+    yaml_file.write_text(
+        f"""
+        test1:
+          depends_components:
+            - if: IDF_VERSION == "{IDF_VERSION}"
+              content: [ "VVV" ]
+            - default: ["some_1", "some_2", "some_3"]
+            - 123
+            - 234
+        """,
+        encoding='utf8',
+    )
+    try:
+        Manifest.from_file(yaml_file)
+    except InvalidManifest as e:
+        assert str(e) == 'Current manifest format has to fit either the switch format or the list format.'
+
+
 def test_manifest_with_anchor(tmpdir, monkeypatch):
     yaml_file = tmpdir / 'test.yml'
     yaml_file.write_text(


### PR DESCRIPTION
Implemented SwitchClause to enable the ability to use the following manifest format:
```
folder_foo:
  depends_components:
    - if: IDF_VERSION == "5.2.0":
      content: ["esp_eth"]
    - if: IDF_VERSION == "5.3.0":
      content: ["esp_wifi"]
    - default: ["esp_eth", "esp_wifi"]
```
or
```
folder_foo:
  depends_components:
    - esp_eth_1
    - esp_eth_2
```

closes #105 