### PR TITLE
feat: support postfixes to reuse arrays

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -78,6 +78,80 @@ examples/foo/bar:
     - if: IDF_TARGET == "esp32s2"
 ```
 
+## Enhanced YAML Syntax
+
+### Reuse Lists
+
+To reuse the items defined in a list, you can use the `+` and `-` postfixes respectively. The order of calculation is always `+` first, followed by `-`.
+
+#### Array Elements as Strings
+
+The following YAML code demonstrates how to reuse the elements from a list of strings:
+
+```yaml
+.base_depends_components: &base-depends-components
+  depends_components:
+    - esp_hw_support
+    - esp_rom
+    - esp_wifi
+
+examples/wifi/coexist:
+  <<: *base-depends-components
+  depends_components+:
+    - esp_coex
+  depends_components-:
+    - esp_rom
+```
+
+After interpretation, the resulting YAML will be:
+
+```yaml
+examples/wifi/coexist:
+  depends_components:
+    - esp_hw_support
+    - esp_wifi
+    - esp_coex
+```
+
+This means that the `esp_rom` element is removed, and the `esp_coex` element is added to the `depends_components` list.
+
+#### Array Elements as Dictionaries
+
+In addition to reuse elements from a list of strings, you can also perform these operations on a list of dictionaries. The matching is done based on the `if` key. Here's an example:
+
+```yaml
+.base: &base
+  enable:
+    - if: IDF_VERSION == "5.2.0"
+    - if: IDF_VERSION == "5.3.0"
+
+foo:
+  <<: *base
+  enable+:
+    # this if statement dictionary will override the one defined in `&base`
+    - if: IDF_VERSION == "5.2.0"
+      temp: true
+    - if: IDF_VERSION == "5.4.0"
+      reason: bar
+```
+
+After interpretation, the resulting YAML will be:
+
+```yaml
+foo:
+  enable:
+  - if: IDF_VERSION == "5.3.0"
+  - if: IDF_VERSION == "5.2.0"
+    temp: true
+  - if: IDF_VERSION == "5.4.0"
+    reason: bar
+```
+
+In this case, the `enable` list is extended with the new `if` statement and `reason` dictionary.
+It's important to note that the `if` dictionary defined in the `+` postfix will override the earlier one when the `if` statement matches.
+
+This demonstrates how you can use the `+` and `-` postfixes to extend and remove elements from both string and dictionary lists in our YAML.
+
 ## Practical Example
 
 Here's a practical example:

--- a/idf_build_apps/manifest/manifest.py
+++ b/idf_build_apps/manifest/manifest.py
@@ -6,7 +6,6 @@ import os
 import typing as t
 import warnings
 
-import yaml
 from pyparsing import (
     ParseException,
 )
@@ -18,6 +17,9 @@ from ..constants import (
 from ..utils import (
     InvalidIfClause,
     InvalidManifest,
+)
+from ..yaml import (
+    parse,
 )
 from .if_parser import (
     BOOL_EXPR,
@@ -187,8 +189,7 @@ class Manifest:
 
     @classmethod
     def from_file(cls, path: str) -> 'Manifest':
-        with open(path) as f:
-            manifest_dict = yaml.safe_load(f) or {}
+        manifest_dict = parse(path)
 
         rules: t.List[FolderRule] = []
         for folder, folder_rule in manifest_dict.items():

--- a/idf_build_apps/yaml/__init__.py
+++ b/idf_build_apps/yaml/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+
+from .parser import (
+    parse,
+)
+
+__all__ = ['parse']

--- a/idf_build_apps/yaml/parser.py
+++ b/idf_build_apps/yaml/parser.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+
+import typing as t
+
+import yaml
+
+
+def parse_postfixes(manifest_dict: t.Dict):
+    for folder, folder_rule in manifest_dict.items():
+        if folder.startswith('.'):
+            continue
+        updated_folder: t.Dict = {}
+        sorted_keys = sorted(folder_rule)
+        for key in sorted_keys:
+            if not key.endswith(('+', '-')):
+                updated_folder[key] = folder_rule[key]
+                continue
+
+            operation = key[-1]
+
+            dict_obj = []
+            str_obj = set()
+            for obj in updated_folder[key[:-1]]:
+                if isinstance(obj, t.Dict):
+                    dict_obj.append(obj)
+                else:
+                    str_obj.add(obj)
+
+            for obj in folder_rule[key]:
+                if isinstance(obj, t.Dict):
+                    dict_obj = [obj_j for obj_j in dict_obj if obj['if'] != obj_j['if']]
+                    if operation == '+':
+                        dict_obj.append(obj)
+                else:
+                    str_obj.add(obj) if operation == '+' else str_obj.remove(obj)
+
+            updated_folder[key[:-1]] = dict_obj + sorted(str_obj)
+
+        manifest_dict[folder] = updated_folder
+
+
+def parse(path: str) -> t.Dict:
+    with open(path) as f:
+        manifest_dict = yaml.safe_load(f) or {}
+    parse_postfixes(manifest_dict)
+    return manifest_dict

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -5,6 +5,7 @@ import os
 import shutil
 
 import pytest
+import yaml
 from packaging.version import (
     Version,
 )
@@ -18,6 +19,9 @@ from idf_build_apps.manifest.manifest import (
 )
 from idf_build_apps.utils import (
     InvalidManifest,
+)
+from idf_build_apps.yaml import (
+    parse,
 )
 
 
@@ -84,6 +88,177 @@ bar:
         manifest = Manifest.from_file(yaml_file)
 
     assert manifest.enable_build_targets('bar') == []
+
+
+def test_manifest_with_anchor_and_postfix(tmpdir, monkeypatch):
+    yaml_file = tmpdir / 'test.yml'
+    yaml_file.write_text(
+        """
+.base_depends_components: &base-depends-components
+  depends_components:
+    - esp_hw_support
+    - esp_rom
+    - esp_wifi
+
+examples/wifi/coexist:
+  <<: *base-depends-components
+  depends_components+:
+    - esp_coex
+  depends_components-:
+    - esp_rom
+""",
+        encoding='utf8',
+    )
+
+    manifest = Manifest.from_file(yaml_file)
+    assert manifest.depends_components('examples/wifi/coexist') == ['esp_coex', 'esp_hw_support', 'esp_wifi']
+
+    yaml_file.write_text(
+        """
+.base: &base
+  enable:
+    - if: IDF_VERSION == "5.2.0"
+    - if: IDF_VERSION == "5.3.0"
+
+foo:
+  <<: *base
+  enable+:
+    - if: IDF_VERSION == "5.2.0"
+      temp: true
+    - if: IDF_VERSION == "5.4.0"
+      reason: bar
+""",
+        encoding='utf8',
+    )
+    s_manifest_dict = parse(yaml_file)
+
+    yaml_file.write_text(
+        """
+foo:
+    enable:
+        -   if: IDF_VERSION == "5.3.0"
+        -   if: IDF_VERSION == "5.2.0"
+            temp: true
+        -   if: IDF_VERSION == "5.4.0"
+            reason: bar
+""",
+        encoding='utf8',
+    )
+    with open(yaml_file) as f:
+        manifest_dict = yaml.safe_load(f) or {}
+
+    assert s_manifest_dict['foo'] == manifest_dict['foo']
+
+    yaml_file.write_text(
+        """
+.base: &base
+  enable:
+    - if: IDF_VERSION == "5.3.0"
+
+foo:
+  <<: *base
+  enable+:
+    - if: IDF_VERSION == "5.2.0"
+      temp: true
+    - if: IDF_VERSION == "5.4.0"
+      reason: bar
+""",
+        encoding='utf8',
+    )
+
+    s_manifest_dict = parse(yaml_file)
+
+    yaml_file.write_text(
+        """
+foo:
+    enable:
+        -   if: IDF_VERSION == "5.3.0"
+        -   if: IDF_VERSION == "5.2.0"
+            temp: true
+        -   if: IDF_VERSION == "5.4.0"
+            reason: bar
+""",
+        encoding='utf8',
+    )
+    with open(yaml_file) as f:
+        manifest_dict = yaml.safe_load(f) or {}
+
+    assert s_manifest_dict['foo'] == manifest_dict['foo']
+
+    yaml_file.write_text(
+        """
+.test: &test
+  depends_components:
+    - a
+    - b
+
+foo:
+  <<: *test
+  depends_components+:
+    - c
+
+bar:
+  <<: *test
+  depends_components+:
+    - d
+""",
+        encoding='utf8',
+    )
+    s_manifest_dict = parse(yaml_file)
+    foo = s_manifest_dict['foo']
+    bar = s_manifest_dict['bar']
+    assert foo['depends_components'] == ['a', 'b', 'c']
+    assert bar['depends_components'] == ['a', 'b', 'd']
+    assert id(foo['depends_components']) != id(bar['depends_components'])
+
+    yaml_file.write_text(
+        """
+.test: &test
+  depends_components:
+    - if: 1
+      value: 123
+
+foo:
+  <<: *test
+  depends_components+:
+    - if: 2
+      value: 234
+
+bar:
+  <<: *test
+  depends_components+:
+    - if: 2
+      value: 345
+""",
+        encoding='utf8',
+    )
+    s_manifest_dict = parse(yaml_file)
+    foo = s_manifest_dict['foo']
+    bar = s_manifest_dict['bar']
+    assert id(foo['depends_components']) != id(bar['depends_components'])
+    print(s_manifest_dict)
+
+
+def test_manifest_postfix_order(tmpdir, monkeypatch):
+    yaml_file = tmpdir / 'test.yml'
+    yaml_file.write_text(
+        """
+.base_depends_components: &base-depends-components
+  depends_components:
+    - esp_hw_support
+
+examples/wifi/coexist:
+  <<: *base-depends-components
+  depends_components+:
+    - esp_coex
+  depends_components-:
+    - esp_coex
+""",
+        encoding='utf8',
+    )
+
+    manifest = Manifest.from_file(yaml_file)
+    assert manifest.depends_components('examples/wifi/coexist') == ['esp_hw_support']
 
 
 def test_from_files_duplicates(tmp_path, monkeypatch):


### PR DESCRIPTION
Support '+' and '-' as postfixes to reuse arrays. Support the following array objects:
- Dictionary: Contains 'if' key.
- Single element: Represents a single value.

closes #106