### PR TITLE
Feature: Support Diff Manifest Rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,26 +16,25 @@ repos:
           - license_header.txt        # defaults to: LICENSE.txt
           - --use-current-year
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.5.7'
+    rev: 'v0.6.2'
     hooks:
       - id: ruff
         args: ['--fix']
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v1.11.1'   # 1.9 doesn't support python 3.7
+    rev: 'v1.11.2'
     hooks:
       - id: mypy
         args: ['--warn-unused-ignores']
         additional_dependencies:
-          - pydantic<2.6  # 2.6 does not support python 3.7
+          - pydantic
           - packaging
           - toml
           - pyparsing
           - types-PyYAML
           - types-toml
-          - pytest<8  # 8.0.0 does not support python 3.7
+          - pytest
           - argcomplete>=3
-          - annotated_types<0.7.0 # 0.7.0 does not support python 3.7
   - repo: https://github.com/hfudev/rstfmt
     rev: v0.1.4
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,7 @@ All notable changes to this project will be documented in this file.
 
 ### BREAKING CHANGES
 
-2.x introduces a lot of breaking changes. For a detailed migration guide, please refer to our [Migration From 1.x to 2.x Guide](https://github.com/espressif/idf-build-apps/blob/main/docs/migration/1.x_to_2.x.md)
+2.x introduces a lot of breaking changes. For a detailed migration guide, please refer to our [Migration From 1.x to 2.x Guide](https://docs.espressif.com/projects/idf-build-apps/en/latest/guides/1.x_to_2.x.html)
 
 Here are the breaking changes:
 

--- a/README.md
+++ b/README.md
@@ -75,4 +75,4 @@ Thanks for your contribution! Please refer to our [Contributing Guide](CONTRIBUT
 [hello-world]: https://github.com/espressif/esp-idf/tree/master/examples/get-started/hello_world
 [supported-targets]: https://github.com/espressif/esp-idf/tree/v5.0#esp-idf-release-and-soc-compatibility
 [doc]: https://docs.espressif.com/projects/idf-build-apps/en/latest/
-[api-doc]: https://docs.espressif.com/projects/idf-build-apps/en/latest/api/modules.html
+[api-doc]: https://docs.espressif.com/projects/idf-build-apps/en/latest/references/api/modules.html

--- a/idf_build_apps/finder.py
+++ b/idf_build_apps/finder.py
@@ -38,6 +38,7 @@ def _get_apps_from_path(
     check_warnings: bool = False,
     preserve: bool = True,
     manifest_rootpath: t.Optional[str] = None,
+    modified_manifest_folders: t.Optional[t.Set[str]] = None,
     modified_components: t.Optional[t.List[str]] = None,
     modified_files: t.Optional[t.List[str]] = None,
     check_app_dependencies: bool = False,
@@ -54,8 +55,9 @@ def _get_apps_from_path(
             _app.build_status = BuildStatus.DISABLED
             return include_disabled_apps
 
-        _app._check_should_build(
+        _app.check_should_build(
             manifest_rootpath=manifest_rootpath,
+            modified_manifest_folders=modified_manifest_folders,
             modified_components=modified_components,
             modified_files=modified_files,
             check_app_dependencies=check_app_dependencies,

--- a/idf_build_apps/main.py
+++ b/idf_build_apps/main.py
@@ -178,12 +178,12 @@ def find_apps(
             raise ValueError('Only Support "make" and "cmake"')
     app_cls = build_system
 
-    # always set the manifest rootpath at the very beginning of find_apps in case ESP-IDF switches the branch.
-    Manifest.ROOTPATH = to_absolute_path(manifest_rootpath or os.curdir)
     Manifest.CHECK_MANIFEST_RULES = check_manifest_rules
 
     if manifest_files:
-        App.MANIFEST = Manifest.from_files(to_list(manifest_files))
+        App.MANIFEST = Manifest.from_files(
+            to_list(manifest_files), root_path=to_absolute_path(manifest_rootpath or os.curdir)
+        )
 
     modified_components = to_list(modified_components)
     modified_files = to_list(modified_files)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,4 +158,4 @@ quote-style = "single"
 docstring-code-format = true
 
 [tool.mypy]
-python_version = "3.7"
+python_version = "3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ version_files = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "-s --log-cli-level DEBUG"
 testpaths = [
     "tests",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+# SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 import os
 
@@ -9,6 +9,7 @@ from idf_build_apps import (
     App,
     setup_logging,
 )
+from idf_build_apps.manifest.manifest import FolderRule
 
 
 @pytest.fixture(autouse=True)
@@ -48,3 +49,16 @@ INCLUDE_DIRS ".")
 void app_main(void) {}
 """
         )
+
+
+@pytest.fixture
+def sha_of_enable_only_esp32():
+    sha = FolderRule('test1', enable=[{'if': 'IDF_TARGET == "esp32"'}]).sha
+
+    # !!! ONLY CHANGE IT WHEN NECESSARY !!!
+    assert (
+        sha
+        == '6fd3175a5068c46bccc411efadf3b98314210e775c25c62833998bff8b0cf1bc1daf738326f138f0d6629caa07338428f2aa122e2b830e6ad43662057c7ea0b1'  # noqa: E501
+    )
+
+    return sha

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from idf_build_apps.main import main
+from idf_build_apps.utils import InvalidCommand
+
+
+class FakeArgs:
+    """like what argparse.Namespace does"""
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+@pytest.mark.parametrize(
+    'args, expected_error',
+    [
+        ([], 'the following arguments are required: --output'),
+        (['--output', 'test.sha1'], 'Manifest files are required to dump the SHA values.'),
+        (['--manifest-file', 'test.yml'], 'the following arguments are required: --output'),
+        (['--manifest-file', 'test.yml', '--output', 'test.sha1'], None),
+    ],
+)
+def test_manifest_dump_sha_values(tmpdir, args, expected_error, sha_of_enable_only_esp32, capsys, monkeypatch):
+    os.chdir(tmpdir)
+    Path('test.yml').write_text(
+        """
+foo:
+  enable:
+    - if: IDF_TARGET == "esp32"
+bar:
+  enable:
+    - if: IDF_TARGET == "esp32"
+baz:
+  enable:
+    - if: IDF_TARGET == "esp32"
+""",
+        encoding='utf8',
+    )
+
+    try:
+        with monkeypatch.context() as m:
+            m.setattr(sys, 'argv', ['idf-build-apps', 'dump-manifest-sha', *args])
+
+            if not expected_error:
+                with pytest.warns(UserWarning, match='Folder .+ does not exist.'):
+                    main()
+            else:
+                main()
+    except SystemExit as e:
+        if isinstance(e, InvalidCommand):
+            actual_error = e.args[0]
+        else:
+            actual_error = capsys.readouterr().err
+    else:
+        actual_error = None
+
+    if expected_error:
+        assert actual_error is not None
+        assert expected_error in str(actual_error)
+    else:
+        with open('test.sha1') as fr:
+            assert fr.read() == (
+                f'bar:{sha_of_enable_only_esp32}\n'
+                f'baz:{sha_of_enable_only_esp32}\n'
+                f'foo:{sha_of_enable_only_esp32}\n'
+            )

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -42,9 +42,7 @@ examples/get-started:
 
         # manifest folder invalid
         os.chdir(test_dir)
-        with pytest.warns(
-            UserWarning, match=f'Folder "{IDF_PATH}/examples/get-started/examples/get-started" does not exist'
-        ):
+        with pytest.warns(UserWarning, match=f'Folder "{test_dir}/examples/get-started" does not exist'):
             assert find_apps(str(test_dir), 'esp32', recursive=True, manifest_files=str(yaml_file))
 
     def test_manifest_rootpath_specified(self):

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -21,6 +21,7 @@ from idf_build_apps.constants import (
 from idf_build_apps.main import (
     find_apps,
 )
+from idf_build_apps.manifest.manifest import Manifest
 
 
 class TestFindWithManifest:
@@ -383,6 +384,47 @@ examples/wifi/getting_started:
 
         apps[0].build()
         assert apps[0].build_status == BuildStatus.SKIPPED
+
+    def test_with_modified_manifest(self, tmp_path, sha_of_enable_only_esp32):
+        create_project('foo', tmp_path)
+
+        yaml_file = tmp_path / 'test.yml'
+        yaml_file.write_text(
+            """
+foo:
+    enable:
+        - if: IDF_TARGET == "esp32"
+    depends_components:
+        - foo
+        """,
+            encoding='utf8',
+        )
+        # dump sha
+        Manifest.from_file(str(yaml_file)).dump_sha_values('.sha')
+        sha_abspath = os.path.abspath('.sha')
+
+        # chdir, and modify bar, should not be found
+        os.chdir(tmp_path)
+        apps = find_apps(
+            'foo',
+            'esp32',
+            manifest_files=[yaml_file],
+            modified_components=['bar'],
+            check_manifest_sha_filepath=sha_abspath,
+        )
+        assert not apps
+
+        # touch the sha file, should be found now
+        with open(sha_abspath, 'w') as fw:
+            fw.write(f'foo:{sha_of_enable_only_esp32}')  # change the folder rule
+        apps = find_apps(
+            'foo',
+            'esp32',
+            manifest_files=[yaml_file],
+            modified_components=['bar'],
+            check_manifest_sha_filepath=sha_abspath,
+        )
+        assert len(apps) == 1
 
 
 class TestFindWithSdkconfigFiles:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -47,8 +47,7 @@ test2:
     )
 
     os.chdir(tmpdir)
-    Manifest.ROOTPATH = tmpdir
-    manifest = Manifest.from_file(yaml_file)
+    manifest = Manifest.from_file(yaml_file, root_path=tmpdir)
     msg_fmt = 'Folder "{}" does not exist. Please check your manifest file {}'
 
     # two warnings warn test1 test2 not exists
@@ -63,7 +62,7 @@ test2:
 
     monkeypatch.setattr(idf_build_apps.manifest.manifest.Manifest, 'CHECK_MANIFEST_RULES', True)
     with pytest.raises(InvalidManifest, match=msg_fmt.format(os.path.join(tmpdir, 'test1'), yaml_file)):
-        Manifest.from_file(yaml_file)
+        Manifest.from_file(yaml_file, root_path=tmpdir)
 
     # test with folder that has the same prefix as one of the folders in the manifest
     assert manifest.enable_build_targets('test23') == sorted(SUPPORTED_TARGETS)
@@ -121,9 +120,8 @@ test5:
     )
 
     os.chdir(tmpdir)
-    Manifest.ROOTPATH = tmpdir
     with pytest.warns(UserWarning, match='Folder ".+" does not exist. Please check your manifest file'):
-        manifest = Manifest.from_file(yaml_file)
+        manifest = Manifest.from_file(yaml_file, root_path=tmpdir)
 
     assert manifest.depends_components('test1', None, None) == ['VVV']
     assert manifest.depends_components('test1', None, 'AAA') == ['VVV']
@@ -175,9 +173,8 @@ test1:
         encoding='utf8',
     )
     os.chdir(tmpdir)
-    Manifest.ROOTPATH = tmpdir
     with pytest.warns(UserWarning, match='Folder ".+" does not exist. Please check your manifest file'):
-        manifest = Manifest.from_file(yaml_file)
+        manifest = Manifest.from_file(yaml_file, root_path=tmpdir)
 
     assert manifest.depends_components('test1', None, None) == ['DF']
     assert manifest.depends_components('test1', None, 'CCC') == ['DF']

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -473,6 +473,28 @@ foo:
         Manifest.from_files([str(yaml_file_1), str(yaml_file_2)])
 
 
+def test_manifest_dump_sha(tmpdir, sha_of_enable_only_esp32):
+    yaml_file = tmpdir / 'test.yml'
+    yaml_file.write_text(
+        """
+foo:
+  enable:
+    - if: IDF_TARGET == "esp32"
+bar:
+  enable:
+    - if: IDF_TARGET == "esp32"
+""",
+        encoding='utf8',
+    )
+
+    with pytest.warns(UserWarning, match='Folder ".+" does not exist. Please check your manifest file'):
+        Manifest.from_file(yaml_file).dump_sha_values(str(tmpdir / '.sha'))
+
+    with open(tmpdir / '.sha') as f:
+        assert f.readline() == f'bar:{sha_of_enable_only_esp32}\n'
+        assert f.readline() == f'foo:{sha_of_enable_only_esp32}\n'
+
+
 class TestIfParser:
     def test_idf_version(self, monkeypatch):
         monkeypatch.setattr(idf_build_apps.manifest.if_parser, 'IDF_VERSION', Version('5.9.0'))

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
-import shutil
 
 import pytest
 import yaml
@@ -18,9 +17,11 @@ from idf_build_apps.manifest.if_parser import (
     BOOL_STMT,
 )
 from idf_build_apps.manifest.manifest import (
+    IfClause,
     Manifest,
 )
 from idf_build_apps.utils import (
+    InvalidIfClause,
     InvalidManifest,
 )
 from idf_build_apps.yaml import (
@@ -481,15 +482,11 @@ class TestIfParser:
         statement = 'IDF_VERSION in  ["5.9.0"]'
         assert BOOL_STMT.parseString(statement)[0].get_value('esp32', 'foo') is True
 
+    def test_invalid_if_statement(self):
+        statement = '1'
+        with pytest.raises(InvalidIfClause, match='Invalid if statement: 1'):
+            IfClause(statement)
 
-@pytest.mark.skipif(not shutil.which('idf.py'), reason='idf.py not found')
-def test_idf_version_keywords_type():
-    from idf_build_apps.constants import (
-        IDF_VERSION_MAJOR,
-        IDF_VERSION_MINOR,
-        IDF_VERSION_PATCH,
-    )
-
-    assert isinstance(IDF_VERSION_MAJOR, int)
-    assert isinstance(IDF_VERSION_MINOR, int)
-    assert isinstance(IDF_VERSION_PATCH, int)
+    def test_temporary_must_with_reason(self):
+        with pytest.raises(InvalidIfClause, match='"reason" must be set when "temporary: true"'):
+            IfClause(stmt='IDF_TARGET == "esp32"', temporary=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: 2022-2023 Espressif Systems (Shanghai) CO LTD
+# SPDX-FileCopyrightText: 2022-2024 Espressif Systems (Shanghai) CO LTD
 # SPDX-License-Identifier: Apache-2.0
 import os
+import shutil
 from pathlib import (
     Path,
 )
@@ -134,3 +135,16 @@ def test_files_matches_patterns(tmpdir):
         os.chdir(temp_dir)
         for f in matched_files:
             assert files_matches_patterns(f, abs_pat)
+
+
+@pytest.mark.skipif(not shutil.which('idf.py'), reason='idf.py not found')
+def test_idf_version_keywords_type():
+    from idf_build_apps.constants import (
+        IDF_VERSION_MAJOR,
+        IDF_VERSION_MINOR,
+        IDF_VERSION_PATCH,
+    )
+
+    assert isinstance(IDF_VERSION_MAJOR, int)
+    assert isinstance(IDF_VERSION_MINOR, int)
+    assert isinstance(IDF_VERSION_PATCH, int)


### PR DESCRIPTION
- Support `idf-build-apps dump-manifest-sha` to create a file that includes the folder and its sha value of the FolderRule
- Support `idf-build-apps find --manifest-file ... --check-manifest-sha-filepath .sha_filepath`. All apps apply to the changed manifest rules will be built.