### PR TITLE
fix: negative value for soc caps integer

### DIFF
--- a/idf_build_apps/manifest/soc_header.py
+++ b/idf_build_apps/manifest/soc_header.py
@@ -42,7 +42,7 @@ _name = Word(alphas, alphas + nums + '_')
 # Define value, either a hex, int or a string
 _hex_value = Combine(Literal('0x') + Word(hexnums) + Optional(_literal_suffix).suppress())('hex_value')
 _str_value = QuotedString('"')('str_value')
-_int_value = Word(nums)('int_value') + ~Char('.') + Optional(_literal_suffix)('literal_suffix')
+_int_value = Combine(Optional('-') + Word(nums))('int_value') + ~Char('.') + Optional(_literal_suffix)('literal_suffix')
 
 # Remove optional parenthesis around values
 _value = Optional('(').suppress() + MatchFirst([_hex_value, _str_value, _int_value])('value') + Optional(')').suppress()

--- a/tests/test_soc_caps.py
+++ b/tests/test_soc_caps.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2024 Espressif Systems (Shanghai) CO LTD
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from idf_build_apps.manifest.soc_header import parse_define
+
+
+@pytest.mark.parametrize(
+    's, res',
+    [
+        ('#define SOC_FOO        (4)', '4'),
+        ('#define SOC_FOO        (-4)', '-4'),
+        ('#define SOC_FOO       4', '4'),
+        ('#define SOC_FOO     -4', '-4'),
+    ],
+)
+def test_parse_define_int(s, res):
+    parse_result = parse_define(s)
+    assert parse_result['name'] == 'SOC_FOO'
+    assert parse_result['int_value'] == res


### PR DESCRIPTION
for example 

```c
// in file components/esp_rom/esp32c6/esp_rom_caps.h
#define ESP_ROM_USB_OTG_NUM                 (-1) // No USB_OTG CDC in the ROM, set -1 for Kconfig usage.
```