### PR TITLE
fix: disable rules wrongly ignored when defining CONFIG_IDF_TARGET in sdkconfig files

### DIFF
--- a/idf_build_apps/app.py
+++ b/idf_build_apps/app.py
@@ -419,13 +419,13 @@ class App(BaseModel):
 
     @property
     def supported_targets(self) -> t.List[str]:
-        if self.sdkconfig_files_defined_idf_target:
-            return [self.sdkconfig_files_defined_idf_target]
-
         if self.MANIFEST:
             return self.MANIFEST.enable_build_targets(
                 self.app_dir, self.sdkconfig_files_defined_idf_target, self.config_name
             )
+
+        if self.sdkconfig_files_defined_idf_target:
+            return [self.sdkconfig_files_defined_idf_target]
 
         return DEFAULT_BUILD_TARGETS.get()
 

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -475,7 +475,7 @@ class TestFindWithSdkconfigFiles:
         apps = find_apps(str(tmp_path / 'foo'), 'esp32p4', default_build_targets=['esp32p4'])
         assert len(apps) == 1
 
-    def test_with_sdkconfig_defaults_idf_target_but_disabled_failed(self, tmp_path):
+    def test_with_sdkconfig_defaults_idf_target_but_disabled(self, tmp_path):
         manifest_file = tmp_path / 'manifest.yml'
         manifest_file.write_text(
             f"""
@@ -490,7 +490,7 @@ class TestFindWithSdkconfigFiles:
 
         test_dir = os.path.join(IDF_PATH, 'examples', 'get-started', 'hello_world')
         # according to idf.py, if `CONFIG_IDF_TARGET` is set to `esp32s2`, the app should be built
-        assert find_apps(
+        assert not find_apps(
             test_dir,
             'esp32s2',
             recursive=True,


### PR DESCRIPTION
regression from 6f7203c127ae5073aa7daaaf7ce25080b73b70fa

wrongly modified the test case